### PR TITLE
Fix size and duplex lpr parameters

### DIFF
--- a/e0-lpr.sh
+++ b/e0-lpr.sh
@@ -42,8 +42,13 @@ SIZE=''
 PS3='Select paper size: '
 select OPT in 'DIN A4' 'DIN A3'; do 
   case "${REPLY}" in
-    1|2 )
-      SIZE="${OPT}"
+    1 )
+      SIZE="A4"
+      break
+      ;;
+
+    2 )
+      SIZE='A3'
       break
       ;;
 
@@ -56,7 +61,7 @@ done
 
 DUPLEX=''
 PS3='Select duplex options: '
-select OPT in 'one-sided' 'two-sided long edge' 'two-sided short edge'; do 
+select OPT in 'one-sided' 'two-sided-long-edge' 'two-sided-short-edge'; do 
   case "${REPLY}" in
     1|2|3 )
       DUPLEX="${OPT}"


### PR DESCRIPTION
This PR fixes the `lpr` parameters `media` and `sides`.
- `media`: The DIN part is omitted in the parameter and should only contain the actual size (e.g. A4).
- `sides`: The spaces will also not form a valid parameter value.